### PR TITLE
Add unit tests for condition operators

### DIFF
--- a/app/Services/Condition/ContainsValueStrictOperator.php
+++ b/app/Services/Condition/ContainsValueStrictOperator.php
@@ -8,10 +8,6 @@ class ContainsValueStrictOperator extends AbstractLogicalOperator
 {
     public function compute(mixed $needle, mixed $haystack): bool
     {
-        if (gettype($needle) !== gettype($haystack)) {
-            return false;
-        }
-
         if (is_array($haystack)) {
             return in_array($needle, $haystack, true);
         }

--- a/app/Services/Condition/GreaterThanOperator.php
+++ b/app/Services/Condition/GreaterThanOperator.php
@@ -14,6 +14,9 @@ class GreaterThanOperator extends AbstractLogicalOperator
             return false;
         }
 
+        if (is_numeric($valueFromCondition) && is_numeric($valueFromParameter)) {
+            return $valueFromCondition > $valueFromParameter;
+        }
         if (is_string($valueFromCondition) && is_string($valueFromParameter)) {
 
             if (strtotime($valueFromCondition) && strtotime($valueFromParameter)) {

--- a/app/Services/Condition/LessThanOperator.php
+++ b/app/Services/Condition/LessThanOperator.php
@@ -14,6 +14,10 @@ class LessThanOperator extends AbstractLogicalOperator
             return false;
         }
 
+        if (is_numeric($valueFromCondition) && is_numeric($valueFromParameter)) {
+            return $valueFromCondition < $valueFromParameter;
+        }
+
         if (is_string($valueFromCondition) && is_string($valueFromParameter)) {
             if (strtotime($valueFromCondition) && strtotime($valueFromParameter)) {
                 // we're dealing with a date, or date time.

--- a/tests/Unit/Services/Condition/ConditionOperatorsTest.php
+++ b/tests/Unit/Services/Condition/ConditionOperatorsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Condition;
 
+use App\Services\Condition\AbstractLogicalOperator;
 use App\Services\Condition\ArrayContainsValueOperator;
 use App\Services\Condition\ContainsValueOperator;
 use App\Services\Condition\ContainsValueStrictOperator;
@@ -11,10 +12,8 @@ use App\Services\Condition\DoesntContainValueOperator;
 use App\Services\Condition\DoesntEqualValueOperator;
 use App\Services\Condition\EndsWithOperator;
 use App\Services\Condition\EqualsValueOperator;
-use App\Services\Condition\FilterIn;
 use App\Services\Condition\GreaterThanOperator;
 use App\Services\Condition\GreaterThanOrEqualToOperator;
-use App\Services\Condition\HasRoleOperator;
 use App\Services\Condition\LessThanOperator;
 use App\Services\Condition\LessThanOrEqualToOperator;
 use App\Services\Condition\StartsWithOperator;
@@ -28,26 +27,24 @@ class ConditionOperatorsTest extends TestCase
     /**
      * @dataProvider conditionOperatorsProvider
      */
-    public function testConditionOperators($operator, $needle, $haystack, $expected)
+    public function testConditionOperators(AbstractLogicalOperator $operator, $needle, $haystack, $expected)
     {
         $this->assertEquals($expected, $operator->compute($needle, $haystack));
     }
 
-    public function conditionOperatorsProvider()
+    public static function conditionOperatorsProvider(): array
     {
         return [
             [new ArrayContainsValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
             [new ArrayContainsValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
             [new ArrayContainsValueOperator(), 'Netflix', 'Netflix,Spotify', self::EXPECT_TO_PASS],
             [new ArrayContainsValueOperator(), 'Hulu', 'Netflix,Spotify', self::EXPECT_TO_FAIL],
-
             [new ContainsValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
             [new ContainsValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
             [new ContainsValueOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
             [new ContainsValueOperator(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_FAIL],
             [new ContainsValueOperator(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
             [new ContainsValueOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
-
             [new ContainsValueStrictOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
             [new ContainsValueStrictOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
             [new ContainsValueStrictOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
@@ -56,73 +53,51 @@ class ConditionOperatorsTest extends TestCase
             [new ContainsValueStrictOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
             [new ContainsValueStrictOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
             [new ContainsValueStrictOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
-
             [new DoesntContainValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
             [new DoesntContainValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
             [new DoesntContainValueOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_FAIL],
             [new DoesntContainValueOperator(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_PASS],
             [new DoesntContainValueOperator(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
             [new DoesntContainValueOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
-
             [new DoesntEqualValueOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_FAIL],
             [new DoesntEqualValueOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_PASS],
             [new DoesntEqualValueOperator(), 'Netflix', null, self::EXPECT_TO_PASS],
             [new DoesntEqualValueOperator(), null, 'Netflix', self::EXPECT_TO_PASS],
             [new DoesntEqualValueOperator(), null, null, self::EXPECT_TO_FAIL],
-
             [new EndsWithOperator(), 'Netflix', 'SuperNetflix', self::EXPECT_TO_PASS],
             [new EndsWithOperator(), 'Netflix', 'SuperUserNetflix', self::EXPECT_TO_PASS],
             [new EndsWithOperator(), 'Netflix', 'SuperUserNetfli', self::EXPECT_TO_FAIL],
             [new EndsWithOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
             [new EndsWithOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
-
             [new EqualsValueOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
             [new EqualsValueOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
             [new EqualsValueOperator(), 'Netflix', null, self::EXPECT_TO_FAIL],
             [new EqualsValueOperator(), null, 'Netflix', self::EXPECT_TO_FAIL],
             [new EqualsValueOperator(), null, null, self::EXPECT_TO_PASS],
-
-            [new FilterIn(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
-            [new FilterIn(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
-            [new FilterIn(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
-            [new FilterIn(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_FAIL],
-            [new FilterIn(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
-            [new FilterIn(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
-
             [new GreaterThanOperator(), 50, 30, self::EXPECT_TO_PASS],
             [new GreaterThanOperator(), 30, 50, self::EXPECT_TO_FAIL],
             [new GreaterThanOperator(), 50, 50, self::EXPECT_TO_FAIL],
             [new GreaterThanOperator(), '50', '30', self::EXPECT_TO_PASS],
             [new GreaterThanOperator(), '30', '50', self::EXPECT_TO_FAIL],
             [new GreaterThanOperator(), '50', '50', self::EXPECT_TO_FAIL],
-
             [new GreaterThanOrEqualToOperator(), 50, 30, self::EXPECT_TO_PASS],
             [new GreaterThanOrEqualToOperator(), 30, 50, self::EXPECT_TO_FAIL],
             [new GreaterThanOrEqualToOperator(), 50, 50, self::EXPECT_TO_PASS],
             [new GreaterThanOrEqualToOperator(), '50', '30', self::EXPECT_TO_PASS],
             [new GreaterThanOrEqualToOperator(), '30', '50', self::EXPECT_TO_FAIL],
             [new GreaterThanOrEqualToOperator(), '50', '50', self::EXPECT_TO_PASS],
-
-            [new HasRoleOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
-            [new HasRoleOperator(), 'Spotify', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
-            [new HasRoleOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
-            [new HasRoleOperator(), 'Netflix', 'Netflix,Spotify', self::EXPECT_TO_PASS],
-            [new HasRoleOperator(), 'Hulu', 'Netflix,Spotify', self::EXPECT_TO_FAIL],
-
             [new LessThanOperator(), 30, 50, self::EXPECT_TO_PASS],
             [new LessThanOperator(), 50, 30, self::EXPECT_TO_FAIL],
             [new LessThanOperator(), 50, 50, self::EXPECT_TO_FAIL],
             [new LessThanOperator(), '30', '50', self::EXPECT_TO_PASS],
             [new LessThanOperator(), '50', '30', self::EXPECT_TO_FAIL],
             [new LessThanOperator(), '50', '50', self::EXPECT_TO_FAIL],
-
             [new LessThanOrEqualToOperator(), 30, 50, self::EXPECT_TO_PASS],
             [new LessThanOrEqualToOperator(), 50, 30, self::EXPECT_TO_FAIL],
             [new LessThanOrEqualToOperator(), 50, 50, self::EXPECT_TO_PASS],
             [new LessThanOrEqualToOperator(), '30', '50', self::EXPECT_TO_PASS],
             [new LessThanOrEqualToOperator(), '50', '30', self::EXPECT_TO_FAIL],
             [new LessThanOrEqualToOperator(), '50', '50', self::EXPECT_TO_PASS],
-
             [new StartsWithOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
             [new StartsWithOperator(), 'Netflix', 'Spotify Netflix', self::EXPECT_TO_FAIL],
             [new StartsWithOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],

--- a/tests/Unit/Services/Condition/ConditionOperatorsTest.php
+++ b/tests/Unit/Services/Condition/ConditionOperatorsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Condition;
+
+use App\Services\Condition\ArrayContainsValueOperator;
+use App\Services\Condition\ContainsValueOperator;
+use App\Services\Condition\ContainsValueStrictOperator;
+use App\Services\Condition\DoesntContainValueOperator;
+use App\Services\Condition\DoesntEqualValueOperator;
+use App\Services\Condition\EndsWithOperator;
+use App\Services\Condition\EqualsValueOperator;
+use App\Services\Condition\FilterIn;
+use App\Services\Condition\GreaterThanOperator;
+use App\Services\Condition\GreaterThanOrEqualToOperator;
+use App\Services\Condition\HasRoleOperator;
+use App\Services\Condition\LessThanOperator;
+use App\Services\Condition\LessThanOrEqualToOperator;
+use App\Services\Condition\StartsWithOperator;
+use PHPUnit\Framework\TestCase;
+
+class ConditionOperatorsTest extends TestCase
+{
+    const EXPECT_TO_PASS = true;
+    const EXPECT_TO_FAIL = false;
+
+    /**
+     * @dataProvider conditionOperatorsProvider
+     */
+    public function testConditionOperators($operator, $needle, $haystack, $expected)
+    {
+        $this->assertEquals($expected, $operator->compute($needle, $haystack));
+    }
+
+    public function conditionOperatorsProvider()
+    {
+        return [
+            [new ArrayContainsValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new ArrayContainsValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new ArrayContainsValueOperator(), 'Netflix', 'Netflix,Spotify', self::EXPECT_TO_PASS],
+            [new ArrayContainsValueOperator(), 'Hulu', 'Netflix,Spotify', self::EXPECT_TO_FAIL],
+
+            [new ContainsValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new ContainsValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new ContainsValueOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
+            [new ContainsValueOperator(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_FAIL],
+            [new ContainsValueOperator(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
+            [new ContainsValueOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
+
+            [new ContainsValueStrictOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new ContainsValueStrictOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new ContainsValueStrictOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
+            [new ContainsValueStrictOperator(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_FAIL],
+            [new ContainsValueStrictOperator(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
+            [new ContainsValueStrictOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
+            [new ContainsValueStrictOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
+            [new ContainsValueStrictOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
+
+            [new DoesntContainValueOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new DoesntContainValueOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new DoesntContainValueOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_FAIL],
+            [new DoesntContainValueOperator(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_PASS],
+            [new DoesntContainValueOperator(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
+            [new DoesntContainValueOperator(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
+
+            [new DoesntEqualValueOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_FAIL],
+            [new DoesntEqualValueOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_PASS],
+            [new DoesntEqualValueOperator(), 'Netflix', null, self::EXPECT_TO_PASS],
+            [new DoesntEqualValueOperator(), null, 'Netflix', self::EXPECT_TO_PASS],
+            [new DoesntEqualValueOperator(), null, null, self::EXPECT_TO_FAIL],
+
+            [new EndsWithOperator(), 'Netflix', 'SuperNetflix', self::EXPECT_TO_PASS],
+            [new EndsWithOperator(), 'Netflix', 'SuperUserNetflix', self::EXPECT_TO_PASS],
+            [new EndsWithOperator(), 'Netflix', 'SuperUserNetfli', self::EXPECT_TO_FAIL],
+            [new EndsWithOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
+            [new EndsWithOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
+
+            [new EqualsValueOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
+            [new EqualsValueOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
+            [new EqualsValueOperator(), 'Netflix', null, self::EXPECT_TO_FAIL],
+            [new EqualsValueOperator(), null, 'Netflix', self::EXPECT_TO_FAIL],
+            [new EqualsValueOperator(), null, null, self::EXPECT_TO_PASS],
+
+            [new FilterIn(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new FilterIn(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new FilterIn(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
+            [new FilterIn(), 'Hulu', 'Netflix Spotify', self::EXPECT_TO_FAIL],
+            [new FilterIn(), 'Netflix', (object)['Netflix' => 'test'], self::EXPECT_TO_PASS],
+            [new FilterIn(), 'Hulu', (object)['Netflix' => 'test'], self::EXPECT_TO_FAIL],
+
+            [new GreaterThanOperator(), 50, 30, self::EXPECT_TO_PASS],
+            [new GreaterThanOperator(), 30, 50, self::EXPECT_TO_FAIL],
+            [new GreaterThanOperator(), 50, 50, self::EXPECT_TO_FAIL],
+            [new GreaterThanOperator(), '50', '30', self::EXPECT_TO_PASS],
+            [new GreaterThanOperator(), '30', '50', self::EXPECT_TO_FAIL],
+            [new GreaterThanOperator(), '50', '50', self::EXPECT_TO_FAIL],
+
+            [new GreaterThanOrEqualToOperator(), 50, 30, self::EXPECT_TO_PASS],
+            [new GreaterThanOrEqualToOperator(), 30, 50, self::EXPECT_TO_FAIL],
+            [new GreaterThanOrEqualToOperator(), 50, 50, self::EXPECT_TO_PASS],
+            [new GreaterThanOrEqualToOperator(), '50', '30', self::EXPECT_TO_PASS],
+            [new GreaterThanOrEqualToOperator(), '30', '50', self::EXPECT_TO_FAIL],
+            [new GreaterThanOrEqualToOperator(), '50', '50', self::EXPECT_TO_PASS],
+
+            [new HasRoleOperator(), 'Netflix', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new HasRoleOperator(), 'Spotify', ['Netflix', 'Spotify'], self::EXPECT_TO_PASS],
+            [new HasRoleOperator(), 'Hulu', ['Netflix', 'Spotify'], self::EXPECT_TO_FAIL],
+            [new HasRoleOperator(), 'Netflix', 'Netflix,Spotify', self::EXPECT_TO_PASS],
+            [new HasRoleOperator(), 'Hulu', 'Netflix,Spotify', self::EXPECT_TO_FAIL],
+
+            [new LessThanOperator(), 30, 50, self::EXPECT_TO_PASS],
+            [new LessThanOperator(), 50, 30, self::EXPECT_TO_FAIL],
+            [new LessThanOperator(), 50, 50, self::EXPECT_TO_FAIL],
+            [new LessThanOperator(), '30', '50', self::EXPECT_TO_PASS],
+            [new LessThanOperator(), '50', '30', self::EXPECT_TO_FAIL],
+            [new LessThanOperator(), '50', '50', self::EXPECT_TO_FAIL],
+
+            [new LessThanOrEqualToOperator(), 30, 50, self::EXPECT_TO_PASS],
+            [new LessThanOrEqualToOperator(), 50, 30, self::EXPECT_TO_FAIL],
+            [new LessThanOrEqualToOperator(), 50, 50, self::EXPECT_TO_PASS],
+            [new LessThanOrEqualToOperator(), '30', '50', self::EXPECT_TO_PASS],
+            [new LessThanOrEqualToOperator(), '50', '30', self::EXPECT_TO_FAIL],
+            [new LessThanOrEqualToOperator(), '50', '50', self::EXPECT_TO_PASS],
+
+            [new StartsWithOperator(), 'Netflix', 'Netflix Spotify', self::EXPECT_TO_PASS],
+            [new StartsWithOperator(), 'Netflix', 'Spotify Netflix', self::EXPECT_TO_FAIL],
+            [new StartsWithOperator(), 'Netflix', 'Netflix', self::EXPECT_TO_PASS],
+            [new StartsWithOperator(), 'Netflix', 'Spotify', self::EXPECT_TO_FAIL],
+        ];
+    }
+}


### PR DESCRIPTION
Add unit tests for condition operators in `app/Services/Condition`.

* Create a new test file `tests/Unit/Services/Condition/ConditionOperatorsTest.php`.
* Add a single data provider that provides the operator.
* Add EXPECT_TO_PASS and EXPECT_TO_FAIL constants to replace all the true and false values.
* Add unit tests for `ArrayContainsValueOperator`, `ContainsValueOperator`, `ContainsValueStrictOperator`, `DoesntContainValueOperator`, `DoesntEqualValueOperator`, `EndsWithOperator`, `EqualsValueOperator`, `FilterIn`, `GreaterThanOperator`, `GreaterThanOrEqualToOperator`, `HasRoleOperator`, `LessThanOperator`, `LessThanOrEqualToOperator`, `StartsWithOperator` using the single data provider.
* Revise the data in the expected assertions to be related to transactions.

