### PR TITLE
Add basic get request tests for Inertia routes

### DIFF
--- a/tests/Feature/Http/Controllers/SporkAssetControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkAssetControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkAssetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_assets_route_is_accessible()
+    {
+        $response = $this->get('/-/assets');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_labels_route_is_accessible()
+    {
+        $response = $this->get('/-/labels');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_assets_route_loads_expected_data()
+    {
+        $response = $this->get('/-/assets');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Assets/Index')
+            ->has('assets')
+        );
+    }
+
+    public function test_labels_route_loads_expected_data()
+    {
+        $response = $this->get('/-/labels');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Labels/Index')
+            ->has('labels')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkBankingControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkBankingControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkBankingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_banking_route_is_accessible()
+    {
+        $response = $this->get('/-/banking');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_banking_budgets_route_is_accessible()
+    {
+        $response = $this->get('/-/banking/budgets');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_banking_route_loads_expected_data()
+    {
+        $response = $this->get('/-/banking');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Banking/Index')
+            ->has('accounts')
+            ->has('transactions')
+        );
+    }
+
+    public function test_banking_budgets_route_loads_expected_data()
+    {
+        $response = $this->get('/-/banking/budgets');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Banking/Budgets')
+            ->has('budgets')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkBatchJobControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkBatchJobControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkBatchJobControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_batch_jobs_route_is_accessible()
+    {
+        $response = $this->get('/-/batch-jobs');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_batch_jobs_route_loads_expected_data()
+    {
+        $response = $this->get('/-/batch-jobs');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('BatchJobs/Index')
+            ->has('batchJobs')
+        );
+    }
+
+    public function test_batch_job_show_route_is_accessible()
+    {
+        $batchJob = \App\Models\JobBatch::factory()->create();
+
+        $response = $this->get("/-/batch-jobs/{$batchJob->id}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_batch_job_show_route_loads_expected_data()
+    {
+        $batchJob = \App\Models\JobBatch::factory()->create();
+
+        $response = $this->get("/-/batch-jobs/{$batchJob->id}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('BatchJobs/Show')
+            ->has('batchJob')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkDashboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkDashboardControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkDashboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_route_is_accessible()
+    {
+        $response = $this->get('/-/dashboard');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_dashboard_route_loads_expected_data()
+    {
+        $response = $this->get('/-/dashboard');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Dashboard')
+            ->has('user')
+            ->has('notifications')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkDeploymentControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkDeploymentControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkDeploymentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deployment_detach_route_is_accessible()
+    {
+        $response = $this->post('/-/deployment/{deployment}/detach');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_deployment_attach_route_is_accessible()
+    {
+        $response = $this->post('/-/deployment/{deployment}/attach');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_project_deploy_route_is_accessible()
+    {
+        $response = $this->post('/-/deployment/{project}/deploy');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_deployment_detach_route_loads_expected_data()
+    {
+        $response = $this->post('/-/deployment/{deployment}/detach');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('DeploymentDetach')
+            ->has('deployment')
+        );
+    }
+
+    public function test_deployment_attach_route_loads_expected_data()
+    {
+        $response = $this->post('/-/deployment/{deployment}/attach');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('DeploymentAttach')
+            ->has('deployment')
+        );
+    }
+
+    public function test_project_deploy_route_loads_expected_data()
+    {
+        $response = $this->post('/-/deployment/{project}/deploy');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('ProjectDeploy')
+            ->has('project')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkDomainsControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkDomainsControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkDomainsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_domains_route_is_accessible()
+    {
+        $domain = \App\Models\Domain::factory()->create();
+
+        $response = $this->get('/-/domains/' . $domain->id);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_domains_route_loads_expected_data()
+    {
+        $domain = \App\Models\Domain::factory()->create();
+
+        $response = $this->get('/-/domains/' . $domain->id);
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Domain')
+            ->has('domain')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkFileManagerControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkFileManagerControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkFileManagerControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_file_manager_route_is_accessible()
+    {
+        $response = $this->get('/-/file-manager');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_file_manager_route_loads_expected_data()
+    {
+        $response = $this->get('/-/file-manager');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('FileManager')
+            ->has('files')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkInboxControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkInboxControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkInboxControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_inbox_route_is_accessible()
+    {
+        $response = $this->get('/-/inbox');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_inbox_message_route_is_accessible()
+    {
+        $messageId = 1; // Replace with a valid message ID
+        $response = $this->get("/-/inbox/{$messageId}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_inbox_route_loads_expected_data()
+    {
+        $response = $this->get('/-/inbox');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Inbox')
+            ->has('messages')
+        );
+    }
+
+    public function test_inbox_message_route_loads_expected_data()
+    {
+        $messageId = 1; // Replace with a valid message ID
+        $response = $this->get("/-/inbox/{$messageId}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('InboxMessage')
+            ->has('message')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkManageControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkManageControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkManageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_manage_slug_route_is_accessible()
+    {
+        $response = $this->get('/-/manage/{slug}');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_manage_route_is_accessible()
+    {
+        $response = $this->get('/-/manage');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_manage_slug_route_loads_expected_data()
+    {
+        $response = $this->get('/-/manage/{slug}');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Manage/Show')
+            ->has('slug')
+            ->has('data')
+        );
+    }
+
+    public function test_manage_route_loads_expected_data()
+    {
+        $response = $this->get('/-/manage');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Manage/Index')
+            ->has('data')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkNotificationsControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkNotificationsControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkNotificationsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notifications_route_is_accessible()
+    {
+        $response = $this->get('/-/notifications');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_notifications_route_loads_expected_data()
+    {
+        $response = $this->get('/-/notifications');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Notifications')
+            ->has('notifications')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkPagesControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkPagesControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkPagesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pages_create_route_is_accessible()
+    {
+        $response = $this->get('/-/pages/create');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_pages_create_route_loads_expected_data()
+    {
+        $response = $this->get('/-/pages/create');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Pages/Create')
+            ->has('user')
+            ->has('errors')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkPostalControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkPostalControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkPostalControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_postal_route_is_accessible()
+    {
+        $response = $this->get('/-/postal');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_postal_email_route_is_accessible()
+    {
+        $emailId = 1; // Assuming an email with ID 1 exists for testing
+        $response = $this->get("/-/postal/{$emailId}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_postal_route_loads_expected_data()
+    {
+        $response = $this->get('/-/postal');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Postal/Index')
+            ->has('emails')
+        );
+    }
+
+    public function test_postal_email_route_loads_expected_data()
+    {
+        $emailId = 1; // Assuming an email with ID 1 exists for testing
+        $response = $this->get("/-/postal/{$emailId}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Postal/Show')
+            ->has('email')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkProjectsControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkProjectsControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Project;
+
+class SporkProjectsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_projects_route_is_accessible()
+    {
+        $response = $this->get('/-/projects');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_projects_create_route_is_accessible()
+    {
+        $response = $this->get('/-/projects/create');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_projects_show_route_is_accessible()
+    {
+        $project = Project::factory()->create();
+
+        $response = $this->get("/-/projects/{$project->id}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_projects_route_loads_expected_data()
+    {
+        $response = $this->get('/-/projects');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Projects/Index')
+            ->has('projects')
+        );
+    }
+
+    public function test_projects_show_route_loads_expected_data()
+    {
+        $project = Project::factory()->create();
+
+        $response = $this->get("/-/projects/{$project->id}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Projects/Show')
+            ->has('project')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkResearchControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkResearchControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkResearchControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_research_route_is_accessible()
+    {
+        $response = $this->get('/-/research');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_research_route_loads_expected_data()
+    {
+        $response = $this->get('/-/research');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Research/Index')
+            ->has('researches')
+        );
+    }
+
+    public function test_research_show_route_is_accessible()
+    {
+        $research = \App\Models\Research::factory()->create();
+
+        $response = $this->get("/-/research/{$research->id}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_research_show_route_loads_expected_data()
+    {
+        $research = \App\Models\Research::factory()->create();
+
+        $response = $this->get("/-/research/{$research->id}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Research/Show')
+            ->has('research')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkRssFeedsControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkRssFeedsControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkRssFeedsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rss_feeds_route_is_accessible()
+    {
+        $response = $this->get('/-/rss-feeds');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_rss_feeds_route_loads_expected_data()
+    {
+        $response = $this->get('/-/rss-feeds');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('RssFeeds/Index')
+            ->has('feeds')
+            ->has('pagination')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkSearchControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkSearchControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkSearchControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_search_route_is_accessible()
+    {
+        $response = $this->get('/-/search');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_search_route_loads_expected_data()
+    {
+        $response = $this->get('/-/search');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Search')
+            ->has('results')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkServersControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkServersControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkServersControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_servers_route_is_accessible()
+    {
+        $response = $this->get('/-/servers');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_console_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}/console");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_keys_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}/keys");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_workers_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}/workers");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_crontab_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}/crontab");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_server_logs_route_is_accessible()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}/logs");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_servers_route_loads_expected_data()
+    {
+        $response = $this->get('/-/servers');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Servers/Index')
+            ->has('servers')
+        );
+    }
+
+    public function test_servers_server_route_loads_expected_data()
+    {
+        $server = \App\Models\Server::factory()->create();
+
+        $response = $this->get("/-/servers/{$server->id}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Servers/Show')
+            ->has('server')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkSettingsControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkSettingsControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkSettingsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_settings_route_is_accessible()
+    {
+        $response = $this->get('/-/settings');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_settings_route_loads_expected_data()
+    {
+        $response = $this->get('/-/settings');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('Settings')
+            ->has('user')
+            ->has('settings')
+        );
+    }
+}

--- a/tests/Feature/Http/Controllers/SporkTagManagerControllerTest.php
+++ b/tests/Feature/Http/Controllers/SporkTagManagerControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SporkTagManagerControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tag_manager_route_is_accessible()
+    {
+        $response = $this->get('/-/tag-manager');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_tag_manager_tag_route_is_accessible()
+    {
+        $tag = \App\Models\Tag::factory()->create();
+
+        $response = $this->get("/-/tag-manager/{$tag->id}");
+
+        $response->assertStatus(200);
+    }
+
+    public function test_tag_manager_route_loads_expected_data()
+    {
+        $response = $this->get('/-/tag-manager');
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('TagManager')
+            ->has('tags')
+        );
+    }
+
+    public function test_tag_manager_tag_route_loads_expected_data()
+    {
+        $tag = \App\Models\Tag::factory()->create();
+
+        $response = $this->get("/-/tag-manager/{$tag->id}");
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('TagManager/Show')
+            ->has('tag')
+        );
+    }
+}


### PR DESCRIPTION
Add basic GET request tests for all declared web routes serving Inertia responses.

* Add `SporkDashboardControllerTest.php` to test the accessibility and data loading of the `/-/dashboard` route.
* Add `SporkSearchControllerTest.php` to test the accessibility and data loading of the `/-/search` route.
* Add `SporkNotificationsControllerTest.php` to test the accessibility and data loading of the `/-/notifications` route.
* Add `SporkRssFeedsControllerTest.php` to test the accessibility and data loading of the `/-/rss-feeds` route.
* Add `SporkBatchJobControllerTest.php` to test the accessibility and data loading of the `/-/batch-jobs` and `/-/batch-jobs/{batch_job}` routes.
* Add `SporkProjectsControllerTest.php` to test the accessibility and data loading of the `/-/projects`, `/-/projects/create`, and `/-/projects/{project}` routes.
* Add `SporkPagesControllerTest.php` to test the accessibility and data loading of the `/-/pages/create` route.
* Add `SporkServersControllerTest.php` to test the accessibility and data loading of the `/-/servers`, `/-/servers/{server}`, `/-/servers/{server}/console`, `/-/servers/{server}/keys`, `/-/servers/{server}/workers`, `/-/servers/{server}/crontab`, and `/-/servers/{server}/logs` routes.
* Add `SporkDomainsControllerTest.php` to test the accessibility and data loading of the `/-/domains/{domain}` route.
* Add `SporkDeploymentControllerTest.php` to test the accessibility and data loading of the `/-/deployment/{deployment}/detach`, `/-/deployment/{deployment}/attach`, and `/-/deployment/{project}/deploy` routes.
* Add `SporkBankingControllerTest.php` to test the accessibility and data loading of the `/-/banking` and `/-/banking/budgets` routes.
* Add `SporkFileManagerControllerTest.php` to test the accessibility and data loading of the `/-/file-manager` route.
* Add `SporkInboxControllerTest.php` to test the accessibility and data loading of the `/-/inbox` and `/-/inbox/{message}` routes.
* Add `SporkPostalControllerTest.php` to test the accessibility and data loading of the `/-/postal` and `/-/postal/{email}` routes.
* Add `SporkManageControllerTest.php` to test the accessibility and data loading of the `/-/manage/{slug}` and `/-/manage` routes.
* Add `SporkSettingsControllerTest.php` to test the accessibility and data loading of the `/-/settings` route.
* Add `SporkTagManagerControllerTest.php` to test the accessibility and data loading of the `/-/tag-manager` and `/-/tag-manager/{tag}` routes.
* Add `SporkResearchControllerTest.php` to test the accessibility and data loading of the `/-/research` and `/-/research/{research}` routes.
* Add `SporkAssetControllerTest.php` to test the accessibility and data loading of the `/-/assets` and `/-/labels` routes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/austinkregel/spork?shareId=XXXX-XXXX-XXXX-XXXX).